### PR TITLE
Dev eryondon fixissuelink

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Generate packageSourceMapping section without any prefixing:
 
 ## Feedback
 
-File NuGet.Client bugs in the [NuGet/PackageSourceMapper](https://github.com/NuGet/PackageSourceMapper/issues) 
+File NuGet.Client bugs in the [NuGet/PackageSourceMapper](https://github.com/NuGet/PackageSourceMapper/issues)

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Generate packageSourceMapping section without any prefixing:
 
 ## Feedback
 
-File NuGet.Client bugs in the [NuGet/Home](https://github.com/nuget/home/issues)
+File NuGet.Client bugs in the [NuGet/PackageSourceMapper](https://github.com/NuGet/PackageSourceMapper/issues) 


### PR DESCRIPTION
Fix  PackageSourceMapper issue link, instead of pointing NuGet/Home it points to own.