### PR TITLE
enable codeql static analysis on official builds

### DIFF
--- a/.config/TSAOptions.json
+++ b/.config/TSAOptions.json
@@ -1,7 +1,7 @@
 
 {
     "tsaVersion": "TsaV2",
-    "codebaseName": "nuget-packageSourceMapper",
+    "codebaseName": "NuGet.PackageSourceMapper_dev",
     "instanceUrl": "DEVDIV",
     "projectName": "DevDiv",
     "areaPath": "DevDiv\\NuGet\\NuGet Clients",

--- a/.config/TSAOptions.json
+++ b/.config/TSAOptions.json
@@ -1,0 +1,9 @@
+{
+    "tsaVersion": "TsaV2",
+    "codebaseName": "nuget-packageSourceMapper",
+    "instanceUrl": "DEVDIV",
+    "projectName": "DevDiv",
+    "areaPath": "DevDiv\\NuGet\\NuGet Clients",
+    "iterationPath": "DevDiv",
+    "allTools": true
+}

--- a/.config/TSAOptions.json
+++ b/.config/TSAOptions.json
@@ -1,3 +1,4 @@
+
 {
     "tsaVersion": "TsaV2",
     "codebaseName": "nuget-packageSourceMapper",

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -35,18 +35,18 @@ stages:
 
     steps:
     - bash: |
-        echo 'Sign type:' $(SignType)
-        echo 'Codeql.Enabled:' '$(Codeql.Enabled)' $(variables['Codeql.Enabled'])  ${{ Codeql.Enabled }}
-        echo 'Codeql.TSAEnabled:' '$(Codeql.TSAEnabled)' $(variables['Codeql.TSAEnabled'])  ${{ Codeql.TSAEnabled }}
         if [ "$(SignType)" = "Real" ]; then
-            echo "##vso[task.setvariable variable=Codeql.Enabled]true"
-            echo "##vso[task.setvariable variable=Codeql.TSAEnabled]true"
+          echo 'Codeql scan enabled'
+          echo "##vso[task.setvariable variable=Codeql.Enabled]true"
+          echo "##vso[task.setvariable variable=Codeql.TSAEnabled]true"
+        else
+          echo 'Codeql scan Disabled'
         fi     
-      displayName: "Print env var"    
+      displayName: "Set CodeQl variables"    
 
     - task: CodeQL3000Init@0
       displayName: Initialize CodeQL
-      condition: "and(succeeded(), eq(variables['Codeql.Enabled'], 'Real'))"
+      condition: "and(succeeded(), eq(variables['Codeql.Enabled'], 'true'))"
 
     - task: NuGetAuthenticate@0
         
@@ -72,7 +72,7 @@ stages:
 
     - task: CodeQL3000Finalize@0
       displayName: Finalize CodeQL
-      condition: "and(succeeded(), eq(variables['Codeql.Enabled'], 'Real'))"
+      condition: "and(succeeded(), eq(variables['Codeql.Enabled'], 'true'))"
 
     - template: eng\common\templates\steps\generate-sbom.yml
 

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -9,9 +9,9 @@ variables:
   - name: _DotNetValidationArtifactsCategory
     value: .NETCoreValidation
   - name: Codeql.Enabled
-    value: $(SignType) -eq "Real"
+    value: false
   - name: Codeql.TSAEnabled
-    value:  $(SignType) -eq "Real"
+    value:  false
 
 # Branches that trigger a build on commit
 trigger:
@@ -26,7 +26,7 @@ stages:
   pool:
     name: NetCore1ESPool-Internal
     demands: 
-      - ImageOverride -equals Build.Windows.Amd64.VS2022
+      - ImageOverride -equals 1es-windows-2022
       - cmd
 
   jobs:
@@ -34,9 +34,19 @@ stages:
     displayName: Official Build
 
     steps:
+    - bash: |
+        echo 'Sign type:' $(SignType)
+        echo 'Codeql.Enabled:' '$(Codeql.Enabled)' $(variables['Codeql.Enabled'])  ${{ Codeql.Enabled }}
+        echo 'Codeql.TSAEnabled:' '$(Codeql.TSAEnabled)' $(variables['Codeql.TSAEnabled'])  ${{ Codeql.TSAEnabled }}
+        if [ "$(SignType)" = "Real" ]; then
+            echo "##vso[task.setvariable variable=Codeql.Enabled]true"
+            echo "##vso[task.setvariable variable=Codeql.TSAEnabled]true"
+        fi     
+      displayName: "Print env var"    
+
     - task: CodeQL3000Init@0
       displayName: Initialize CodeQL
-      condition: "and(succeeded(), eq(variables['Codeql.Enabled'], 'true'))"
+      condition: "and(succeeded(), eq(variables['Codeql.Enabled'], 'Real'))"
 
     - task: NuGetAuthenticate@0
         
@@ -62,7 +72,7 @@ stages:
 
     - task: CodeQL3000Finalize@0
       displayName: Finalize CodeQL
-      condition: "and(succeeded(), eq(variables['Codeql.Enabled'], 'true'))"
+      condition: "and(succeeded(), eq(variables['Codeql.Enabled'], 'Real'))"
 
     - template: eng\common\templates\steps\generate-sbom.yml
 

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -8,6 +8,10 @@ variables:
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory
     value: .NETCoreValidation
+  - name: Codeql.Enabled
+    value: $(SignType) -eq "Real"
+  - name: Codeql.TSAEnabled
+    value:  $(SignType) -eq "Real"
 
 # Branches that trigger a build on commit
 trigger:
@@ -30,6 +34,10 @@ stages:
     displayName: Official Build
 
     steps:
+    - task: CodeQL3000Init@0
+      displayName: Initialize CodeQL
+      condition: "and(succeeded(), eq(variables['Codeql.Enabled'], 'true'))"
+
     - task: NuGetAuthenticate@0
         
     - task: MicroBuildSigningPlugin@3
@@ -51,6 +59,10 @@ stages:
                 /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                 /p:DotnetPublishUsingPipelines=true
       displayName: Build
+
+    - task: CodeQL3000Finalize@0
+      displayName: Finalize CodeQL
+      condition: "and(succeeded(), eq(variables['Codeql.Enabled'], 'true'))"
 
     - template: eng\common\templates\steps\generate-sbom.yml
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/1946

Description:
Enabled CodeQL static analysis on when signing the tool. CI pipeline build run log is [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=2042284&view=logs&j=03279fe8-b96b-5477-e824-c46ea6c29bf6&t=02e5cb2e-a731-5483-431b-0d8d6998c6a1&l=1).