### PR TITLE
Keep package original casing when generating recommendation

### DIFF
--- a/PackageSourceMapper/GenerateCommand.cs
+++ b/PackageSourceMapper/GenerateCommand.cs
@@ -133,11 +133,8 @@ namespace NuGet.PackageSourceMapper
 
             try
             {
-                using (Stream stream = File.OpenRead(nuspecPath))
-                {
-                    Manifest manifest = Manifest.ReadFrom(stream, validateSchema: false);
-                    return manifest.Metadata.Id;
-                }
+                NuspecReader nuspecReader = new NuspecReader(nuspecPath);
+                return nuspecReader.GetId();
             }
             catch (Exception ex)
             {

--- a/PackageSourceMapper/GenerateCommand.cs
+++ b/PackageSourceMapper/GenerateCommand.cs
@@ -54,6 +54,8 @@ namespace NuGet.PackageSourceMapper
                     var pathParts = metadataPath.Split(Path.DirectorySeparatorChar);
                     string packageId = pathParts[pathParts.Length - 3];
                     var packageVersion = Versioning.NuGetVersion.Parse(pathParts[pathParts.Length - 2]);
+                    string nuspecPath = Path.Combine(Path.GetDirectoryName(metadataPath), $"{packageId}.nuspec");
+                    packageId = GetPackageIdWithOriginalCasing(nuspecPath, logger) ?? packageId;
                     PackageIdentity packageIdentity = new PackageIdentity(packageId, packageVersion);
 
                     var sourcePath = metadata.Source;
@@ -120,6 +122,28 @@ namespace NuGet.PackageSourceMapper
             Console.WriteLine(string.Format(LocalizedResourceManager.GetString("FinishGeneration")));
             Console.WriteLine(string.Empty);
             logger.LogMinimal(string.Format(LocalizedResourceManager.GetString("VerifyResult")));
+        }
+
+        private static string GetPackageIdWithOriginalCasing(string nuspecPath, ILogger logger)
+        {
+            if (string.IsNullOrEmpty(nuspecPath) || !File.Exists(nuspecPath))
+            {
+                return null;
+            }
+
+            try
+            {
+                using (Stream stream = File.OpenRead(nuspecPath))
+                {
+                    Manifest manifest = Manifest.ReadFrom(stream, validateSchema: false);
+                    return manifest.Metadata.Id;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("    " + ex.Message);
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/PackageSourceMapper/issues/8

Currently we're generating recommendation all lowercase, but if we match with original casing then it would be more human readable. See below example:

![image](https://user-images.githubusercontent.com/8766776/220770988-39d8fc19-946e-40fe-bf4a-c1409094aa6f.png)
