### PR TITLE
Allow PackageSourceMapper to report sources that are unused add configure the minimal set

### DIFF
--- a/PackageSourceMapper/Common/Request.cs
+++ b/PackageSourceMapper/Common/Request.cs
@@ -7,5 +7,6 @@ namespace NuGet.PackageSourceMapper
         public string GlobalPackagesFolder { get; set; }
         public ISettings Settings { get; set; }
         public bool IdPatternOnlyOption { get; set; }
+        public bool ReduceSourcesOption { get; set; }
     }
 }

--- a/PackageSourceMapper/Common/Request.cs
+++ b/PackageSourceMapper/Common/Request.cs
@@ -7,6 +7,6 @@ namespace NuGet.PackageSourceMapper
         public string GlobalPackagesFolder { get; set; }
         public ISettings Settings { get; set; }
         public bool IdPatternOnlyOption { get; set; }
-        public bool ReduceSourcesOption { get; set; }
+        public bool ReduceUnusedSourcesOption { get; set; }
     }
 }

--- a/PackageSourceMapper/Common/Request.cs
+++ b/PackageSourceMapper/Common/Request.cs
@@ -7,6 +7,6 @@ namespace NuGet.PackageSourceMapper
         public string GlobalPackagesFolder { get; set; }
         public ISettings Settings { get; set; }
         public bool IdPatternOnlyOption { get; set; }
-        public bool ReduceUnusedSourcesOption { get; set; }
+        public bool RemoveUnusedSourcesOption { get; set; }
     }
 }

--- a/PackageSourceMapper/GenerateCommand.cs
+++ b/PackageSourceMapper/GenerateCommand.cs
@@ -14,7 +14,7 @@ namespace NuGet.PackageSourceMapper
 {
     internal static partial class GenerateCommandHandler
     {
-        private static void Execute(Request request, ILogger logger)
+        private static void Execute(Request request, ILogger logger, Dictionary<PackageSource, SourceRepository> _sourceRepositoryCache)
         {
             Dictionary<string, PackageSource> definedSourcesDict = null;
             HashSet<string> undefinedSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -115,7 +115,7 @@ namespace NuGet.PackageSourceMapper
             PrintStatistics(sources, logger);
 
             // Probe sources for package availability and update them.
-            ConcurrentDictionary<PackageIdentity, PackageSource> packageSourceLookup = ProbSources(request, sources, logger);
+            ConcurrentDictionary<PackageIdentity, PackageSource> packageSourceLookup = ProbSourcesAsync(request, sources, _sourceRepositoryCache, logger).Result;
 
             GeneratePackageSourceMappingSection(request, packageSourceLookup, logger);
 

--- a/PackageSourceMapper/GenerateCommand.cs
+++ b/PackageSourceMapper/GenerateCommand.cs
@@ -9,12 +9,13 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace NuGet.PackageSourceMapper
 {
     internal static partial class GenerateCommandHandler
     {
-        private static void Execute(Request request, ILogger logger, Dictionary<PackageSource, SourceRepository> _sourceRepositoryCache)
+        private static async Task ExecuteAsync(Request request, ILogger logger, Dictionary<PackageSource, SourceRepository> _sourceRepositoryCache)
         {
             Dictionary<string, PackageSource> definedSourcesDict = null;
             HashSet<string> undefinedSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -115,7 +116,7 @@ namespace NuGet.PackageSourceMapper
             PrintStatistics(sources, logger);
 
             // Probe sources for package availability and update them.
-            ConcurrentDictionary<PackageIdentity, PackageSource> packageSourceLookup = ProbSourcesAsync(request, sources, _sourceRepositoryCache, logger).Result;
+            ConcurrentDictionary<PackageIdentity, PackageSource> packageSourceLookup = await ProbSourcesAsync(request, sources, _sourceRepositoryCache, logger);
 
             GeneratePackageSourceMappingSection(request, packageSourceLookup, logger);
 

--- a/PackageSourceMapper/GenerateCommandHandler.cs
+++ b/PackageSourceMapper/GenerateCommandHandler.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Binding;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace NuGet.PackageSourceMapper
 {
@@ -20,9 +21,9 @@ namespace NuGet.PackageSourceMapper
         private static Dictionary<string, PackageSource> _packageSourceObjectLookup = new();
 
         // This signature must be exactly same as Generate method, including var names, and Option names.
-        delegate int GenerateDelegate(string configPath, string verbosity, bool fullySpecified, bool reduceUnusedSources);
+        delegate Task<int> GenerateDelegateAsync(string configPath, string verbosity, bool fullySpecified, bool reduceUnusedSources);
 
-        private static int Generate(string configPath, string verbosity, bool fullySpecified, bool reduceUnusedSources)
+        private static async Task<int> GenerateAsync(string configPath, string verbosity, bool fullySpecified, bool reduceUnusedSources)
         {
             int ret = ReturnCode.Ok;
             Logger logger = new Logger();
@@ -120,7 +121,7 @@ namespace NuGet.PackageSourceMapper
                 ReduceUnusedSourcesOption = reduceUnusedSources,
             };
 
-            Execute(request, logger, _sourceRepositoryCache);
+            await ExecuteAsync(request, logger, _sourceRepositoryCache);
 
             return ret;
         }
@@ -131,7 +132,7 @@ namespace NuGet.PackageSourceMapper
                 name: "generate",
                 description: "This command generate package source mapping section for package source mapping feature from solution/project's nuget.config file or global packages folder. Please run this tool after NuGet package restore, it'll genereate nugetPackageSourceMapping.config file if successfull, also it detects when a NuGet package id is on more than one feeds and if there is any content discrepency between source and file on disc. For more info check https://devblogs.microsoft.com/nuget/introducing-package-source-mapping/")
             {
-                Handler = HandlerDescriptor.FromDelegate((GenerateDelegate)Generate).GetCommandHandler()
+                Handler = HandlerDescriptor.FromDelegate((GenerateDelegateAsync)GenerateAsync).GetCommandHandler()
             };
 
             generateCommand.AddArgument(config());

--- a/PackageSourceMapper/GenerateCommandHandler.cs
+++ b/PackageSourceMapper/GenerateCommandHandler.cs
@@ -20,9 +20,9 @@ namespace NuGet.PackageSourceMapper
         private static Dictionary<string, PackageSource> _packageSourceObjectLookup = new();
 
         // This signature must be exactly same as Generate method, including var names, and Option names.
-        delegate int GenerateDelegate(string configPath, string verbosity, bool fullySpecified);
+        delegate int GenerateDelegate(string configPath, string verbosity, bool fullySpecified, bool reduceSources);
 
-        private static int Generate(string configPath, string verbosity, bool fullySpecified)
+        private static int Generate(string configPath, string verbosity, bool fullySpecified, bool reduceSources)
         {
             int ret = ReturnCode.Ok;
             Logger logger = new Logger();
@@ -36,12 +36,14 @@ namespace NuGet.PackageSourceMapper
             Console.WriteLine($"    configPath : {configPath}");
             Console.WriteLine($"    --verbosity : {verbosity}");
             Console.WriteLine($"    --fully-specified : {fullySpecified}");
+            Console.WriteLine($"    --reduce-sources : {reduceSources}");
             Console.WriteLine(string.Empty);
 #else
             logger.LogVerbose("Parameters:");
             logger.LogVerbose($"    configPath : {configPath}");
             logger.LogVerbose($"    --verbosity : {verbosity}");
             logger.LogVerbose($"    --fully-specified : {fullySpecified}");
+            logger.LogVerbose($"    --reduce-sources : {reduceSources}");
             logger.LogVerbose(string.Empty);
 #endif
 
@@ -115,9 +117,10 @@ namespace NuGet.PackageSourceMapper
                 GlobalPackagesFolder = globalPackageFolder,
                 Settings = settings,
                 IdPatternOnlyOption = fullySpecified,
+                ReduceSourcesOption = reduceSources,
             };
 
-            Execute(request, logger);
+            Execute(request, logger, _sourceRepositoryCache);
 
             return ret;
         }
@@ -134,6 +137,7 @@ namespace NuGet.PackageSourceMapper
             generateCommand.AddArgument(config());
             generateCommand.AddOption(Verbosity());
             generateCommand.AddOption(FullySpecifiedOption());
+            generateCommand.AddOption(ReduceSourcesOption());
             return generateCommand;
         }
 
@@ -154,6 +158,11 @@ namespace NuGet.PackageSourceMapper
             new Option(
                 aliases: new[] { "--fully-specified" },
                 description: "Specify this option to generate full specified pattern instead without prefix.");
+
+        private static Option ReduceSourcesOption() =>
+            new Option(
+                aliases: new[] { "--reduce-sources" },
+                description: "Specify this option if the packagesourcemapper should attempt to reduce the number of sources used in nuget.config by consolidating them");
 
         /// <summary>
         /// Note that the .NET CLI itself has parameter parsing which limits the values that will be passed here by the

--- a/PackageSourceMapper/GenerateCommandHandler.cs
+++ b/PackageSourceMapper/GenerateCommandHandler.cs
@@ -23,7 +23,7 @@ namespace NuGet.PackageSourceMapper
         // This signature must be exactly same as Generate method, including var names, and Option names.
         delegate Task<int> GenerateDelegateAsync(string configPath, string verbosity, bool fullySpecified, bool reduceUnusedSources);
 
-        private static async Task<int> GenerateAsync(string configPath, string verbosity, bool fullySpecified, bool reduceUnusedSources)
+        private static async Task<int> GenerateAsync(string configPath, string verbosity, bool fullySpecified, bool removeUnusedSources)
         {
             int ret = ReturnCode.Ok;
             Logger logger = new Logger();
@@ -37,14 +37,14 @@ namespace NuGet.PackageSourceMapper
             Console.WriteLine($"    configPath : {configPath}");
             Console.WriteLine($"    --verbosity : {verbosity}");
             Console.WriteLine($"    --fully-specified : {fullySpecified}");
-            Console.WriteLine($"    --reduce-unused-sources : {reduceUnusedSources}");
+            Console.WriteLine($"    --remove-unused-sources : {removeUnusedSources}");
             Console.WriteLine(string.Empty);
 #else
             logger.LogVerbose("Parameters:");
             logger.LogVerbose($"    configPath : {configPath}");
             logger.LogVerbose($"    --verbosity : {verbosity}");
             logger.LogVerbose($"    --fully-specified : {fullySpecified}");
-            logger.LogVerbose($"    --reduce-unused-sources : {reduceSources}");
+            logger.LogVerbose($"    --remove-unused-sources : {removeUnusedSources}");
             logger.LogVerbose(string.Empty);
 #endif
 
@@ -118,7 +118,7 @@ namespace NuGet.PackageSourceMapper
                 GlobalPackagesFolder = globalPackageFolder,
                 Settings = settings,
                 IdPatternOnlyOption = fullySpecified,
-                ReduceUnusedSourcesOption = reduceUnusedSources,
+                RemoveUnusedSourcesOption = removeUnusedSources,
             };
 
             await ExecuteAsync(request, logger, _sourceRepositoryCache);
@@ -138,7 +138,7 @@ namespace NuGet.PackageSourceMapper
             generateCommand.AddArgument(config());
             generateCommand.AddOption(Verbosity());
             generateCommand.AddOption(FullySpecifiedOption());
-            generateCommand.AddOption(ReduceUnusedSourcesOption());
+            generateCommand.AddOption(RemoveUnusedSourcesOption());
             return generateCommand;
         }
 
@@ -160,9 +160,9 @@ namespace NuGet.PackageSourceMapper
                 aliases: new[] { "--fully-specified" },
                 description: "Specify this option to generate full specified pattern instead without prefix.");
 
-        private static Option ReduceUnusedSourcesOption() =>
+        private static Option RemoveUnusedSourcesOption() =>
             new Option(
-                aliases: new[] { "--reduce-unused-sources" },
+                aliases: new[] { "--remove-unused-sources" },
                 description: "Specify this option if the packagesourcemapper should attempt to reduce the number of sources used in nuget.config by consolidating them");
 
         /// <summary>

--- a/PackageSourceMapper/GenerateCommandHandler.cs
+++ b/PackageSourceMapper/GenerateCommandHandler.cs
@@ -20,9 +20,9 @@ namespace NuGet.PackageSourceMapper
         private static Dictionary<string, PackageSource> _packageSourceObjectLookup = new();
 
         // This signature must be exactly same as Generate method, including var names, and Option names.
-        delegate int GenerateDelegate(string configPath, string verbosity, bool fullySpecified, bool reduceSources);
+        delegate int GenerateDelegate(string configPath, string verbosity, bool fullySpecified, bool reduceUnusedSources);
 
-        private static int Generate(string configPath, string verbosity, bool fullySpecified, bool reduceSources)
+        private static int Generate(string configPath, string verbosity, bool fullySpecified, bool reduceUnusedSources)
         {
             int ret = ReturnCode.Ok;
             Logger logger = new Logger();
@@ -36,14 +36,14 @@ namespace NuGet.PackageSourceMapper
             Console.WriteLine($"    configPath : {configPath}");
             Console.WriteLine($"    --verbosity : {verbosity}");
             Console.WriteLine($"    --fully-specified : {fullySpecified}");
-            Console.WriteLine($"    --reduce-sources : {reduceSources}");
+            Console.WriteLine($"    --reduce-unused-sources : {reduceUnusedSources}");
             Console.WriteLine(string.Empty);
 #else
             logger.LogVerbose("Parameters:");
             logger.LogVerbose($"    configPath : {configPath}");
             logger.LogVerbose($"    --verbosity : {verbosity}");
             logger.LogVerbose($"    --fully-specified : {fullySpecified}");
-            logger.LogVerbose($"    --reduce-sources : {reduceSources}");
+            logger.LogVerbose($"    --reduce-unused-sources : {reduceSources}");
             logger.LogVerbose(string.Empty);
 #endif
 
@@ -117,7 +117,7 @@ namespace NuGet.PackageSourceMapper
                 GlobalPackagesFolder = globalPackageFolder,
                 Settings = settings,
                 IdPatternOnlyOption = fullySpecified,
-                ReduceSourcesOption = reduceSources,
+                ReduceUnusedSourcesOption = reduceUnusedSources,
             };
 
             Execute(request, logger, _sourceRepositoryCache);
@@ -137,7 +137,7 @@ namespace NuGet.PackageSourceMapper
             generateCommand.AddArgument(config());
             generateCommand.AddOption(Verbosity());
             generateCommand.AddOption(FullySpecifiedOption());
-            generateCommand.AddOption(ReduceSourcesOption());
+            generateCommand.AddOption(ReduceUnusedSourcesOption());
             return generateCommand;
         }
 
@@ -159,9 +159,9 @@ namespace NuGet.PackageSourceMapper
                 aliases: new[] { "--fully-specified" },
                 description: "Specify this option to generate full specified pattern instead without prefix.");
 
-        private static Option ReduceSourcesOption() =>
+        private static Option ReduceUnusedSourcesOption() =>
             new Option(
-                aliases: new[] { "--reduce-sources" },
+                aliases: new[] { "--reduce-unused-sources" },
                 description: "Specify this option if the packagesourcemapper should attempt to reduce the number of sources used in nuget.config by consolidating them");
 
         /// <summary>

--- a/PackageSourceMapper/Sources.cs
+++ b/PackageSourceMapper/Sources.cs
@@ -63,20 +63,21 @@ namespace NuGet.PackageSourceMapper
 
                 foreach (SourceRepository repository in _sourceRepositoryCache.Values)
                 {
-                    PackageMetadataResource resource = await repository.GetResourceAsync<PackageMetadataResource>();
+                    FindPackageByIdResource resource = await repository.GetResourceAsync<FindPackageByIdResource>();
                     sourcesToPackage[repository.PackageSource] = new HashSet<PackageIdentity>();
                     try
                     {
                         logger.LogMinimal(Environment.NewLine + $"Started probing source:{repository.PackageSource} for package availability");
                         foreach (PackageData packageData in allPackages)
                         {
-                            IPackageSearchMetadata packageMeta = await resource.GetMetadataAsync(
-                                packageData.PackageIdentity,
+                            bool exists = await resource.DoesPackageExistAsync(
+                                packageData.PackageIdentity.Id,
+                                packageData.PackageIdentity.Version,
                                 cache,
                                 logger,
                                 CancellationToken.None);
 
-                            if (packageMeta != null)
+                            if (exists)
                             {
                                 logger.LogMinimal($"     {packageData.PackageIdentity} is found in this source.");
                                 sourcesToPackage[repository.PackageSource].Add(packageData.PackageIdentity);

--- a/PackageSourceMapper/Sources.cs
+++ b/PackageSourceMapper/Sources.cs
@@ -54,11 +54,11 @@ namespace NuGet.PackageSourceMapper
             List<PackageSource> sourcesCanBeRemoved = new();
             IOrderedEnumerable<KeyValuePair<PackageSource, HashSet<PackageIdentity>>> sourcesDescendingByPackageCount = null;
 
-            if (request.ReduceSourcesOption)
+            if (request.ReduceUnusedSourcesOption)
             {
                 Dictionary<PackageSource, HashSet<PackageIdentity>> sourcesToPackage = new();
 
-                logger.LogMinimal(Environment.NewLine + "    --reduce-sources option requires internet connection to sources used for restore!");
+                logger.LogMinimal(Environment.NewLine + "    --reduce-unused-sources option requires internet connection to sources used for restore!");
                 SourceCacheContext cache = new SourceCacheContext();
 
                 foreach (SourceRepository repository in _sourceRepositoryCache.Values)
@@ -97,7 +97,7 @@ namespace NuGet.PackageSourceMapper
 
                 List<PackageIdentity> allPackageIdentities = allPackages.Select(x => x.PackageIdentity).ToList();
                 // Simple greedy algorithm, it can be improved later, brute force solution which covers all possible scenario would be O(n!*m) time complexity, here n is number of sources and m is number of packages.
-                // With simple greedy algorithm is O(n)*m.
+                // With simple greedy algorithm is O(n*m).
                 int lastCount = allPackageIdentities.Count;
                 foreach (KeyValuePair<PackageSource, HashSet<PackageIdentity>> sourcePackages in sourcesDescendingByPackageCount)
                 {

--- a/PackageSourceMapper/Sources.cs
+++ b/PackageSourceMapper/Sources.cs
@@ -8,6 +8,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NuGet.PackageSourceMapper
 {
@@ -42,12 +44,99 @@ namespace NuGet.PackageSourceMapper
             return orderedPackageSources;
         }
 
-        private static ConcurrentDictionary<PackageIdentity, PackageSource> ProbSources(Request request, ConcurrentDictionary<string, List<PackageData>> sources, ILogger logger)
+        private static async Task<ConcurrentDictionary<PackageIdentity, PackageSource>> ProbSourcesAsync(
+            Request request,
+            ConcurrentDictionary<string, List<PackageData>> sources,
+            Dictionary<PackageSource, SourceRepository> _sourceRepositoryCache,
+            ILogger logger)
         {
             List<PackageData> allPackages = sources.Values.SelectMany(s => s).Distinct().ToList();
+            List<PackageSource> sourcesCanBeRemoved = new();
+            IOrderedEnumerable<KeyValuePair<PackageSource, HashSet<PackageIdentity>>> sourcesDescendingByPackageCount = null;
+
+            if (request.ReduceSourcesOption)
+            {
+                Dictionary<PackageSource, HashSet<PackageIdentity>> sourcesToPackage = new();
+
+                logger.LogMinimal(Environment.NewLine + "    --reduce-sources option requires internet connection to sources used for restore!");
+                SourceCacheContext cache = new SourceCacheContext();
+
+                foreach (SourceRepository repository in _sourceRepositoryCache.Values)
+                {
+                    PackageMetadataResource resource = await repository.GetResourceAsync<PackageMetadataResource>();
+                    sourcesToPackage[repository.PackageSource] = new HashSet<PackageIdentity>();
+                    try
+                    {
+                        logger.LogMinimal(Environment.NewLine + $"Started probing source:{repository.PackageSource} for package availability");
+                        foreach (PackageData packageData in allPackages)
+                        {
+                            IPackageSearchMetadata packageMeta = await resource.GetMetadataAsync(
+                                packageData.PackageIdentity,
+                                cache,
+                                logger,
+                                CancellationToken.None);
+
+                            if (packageMeta != null)
+                            {
+                                logger.LogMinimal($"     {packageData.PackageIdentity} is found in this source.");
+                                sourcesToPackage[repository.PackageSource].Add(packageData.PackageIdentity);
+                            }
+                            else
+                            {
+                                logger.LogMinimal($"     {packageData.PackageIdentity} is not found in this source.");
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError($"Experienced problem with {repository.PackageSource}: {ex.Message}");
+                    }
+                }
+
+                sourcesDescendingByPackageCount = from entry in sourcesToPackage orderby entry.Value.Count descending select entry;
+
+                List<PackageIdentity> allPackageIdentities = allPackages.Select(x => x.PackageIdentity).ToList();
+                // Simple greedy algorithm, it can be improved later, brute force solution which covers all possible scenario would be O(n!*m) time complexity, here n is number of sources and m is number of packages.
+                // With simple greedy algorithm is O(n)*m.
+                int lastCount = allPackageIdentities.Count;
+                foreach (KeyValuePair<PackageSource, HashSet<PackageIdentity>> sourcePackages in sourcesDescendingByPackageCount)
+                {
+                    if (allPackageIdentities.Count == 0)
+                    {   // If all packages are already covered then we can remove this source.
+                        sourcesCanBeRemoved.Add(sourcePackages.Key);
+                        continue;
+                    }
+
+                    foreach (PackageIdentity packageIdentity in sourcePackages.Value)
+                    {
+                        allPackageIdentities.Remove(packageIdentity);
+                    }
+
+                    if (lastCount == allPackageIdentities.Count)
+                    {
+                        // Nothing removed with this source
+                        sourcesCanBeRemoved.Add(sourcePackages.Key);
+                    }
+                    lastCount = allPackageIdentities.Count;
+                }
+
+                if (sourcesCanBeRemoved.Count > 0)
+                {
+                    logger.LogMinimal(Environment.NewLine + $"The following sources can be removed:because the packages in them are already covered by other sources.");
+
+                    foreach (PackageSource packageSource in sourcesCanBeRemoved)
+                    {
+                        logger.LogMinimal($"   - {packageSource}");
+                    }
+                }
+                else
+                {
+                    logger.LogMinimal(Environment.NewLine + $"The greedy algorithm was unable to find any sources that could be removed, so manual removal may be necessary.");
+                }
+            }
+
             ConcurrentDictionary<PackageIdentity, PackageSource> packageSourceLookup = new();
 
-            // Prob sources for availability of packages and save hashContent from sources so we can compare later.
             packageSourceLookup = new ConcurrentDictionary<PackageIdentity, PackageSource>(allPackages.ToDictionary(p => p.PackageIdentity, p => _packageSourceObjectLookup[p.OriginalSource]));
 
             if (packageSourceLookup.Keys.Count != allPackages.Select(p => p.PackageIdentity).Count())
@@ -62,6 +151,27 @@ namespace NuGet.PackageSourceMapper
 
                 logger.LogMinimal(string.Format(LocalizedResourceManager.GetString("UnresolvedPackages")));
                 Environment.Exit(1);
+            }
+
+            if (sourcesCanBeRemoved.Count > 0 && sourcesDescendingByPackageCount != null)
+            {
+                foreach (PackageIdentity package in packageSourceLookup.Keys)
+                {
+                    PackageSource packageSource = packageSourceLookup[package];
+
+                    if (sourcesCanBeRemoved.Contains(packageSource))
+                    {
+                        // Reassign new source to packages from source with most packages
+                        foreach (KeyValuePair<PackageSource, HashSet<PackageIdentity>> sourcePackages in sourcesDescendingByPackageCount)
+                        {
+                            if (sourcePackages.Value.Contains(package))
+                            {
+                                packageSourceLookup[package] = sourcePackages.Key;
+                                break;
+                            }
+                        }
+                    }
+                }
             }
 
             return packageSourceLookup;

--- a/PackageSourceMapper/Sources.cs
+++ b/PackageSourceMapper/Sources.cs
@@ -54,11 +54,11 @@ namespace NuGet.PackageSourceMapper
             List<PackageSource> sourcesCanBeRemoved = new();
             IOrderedEnumerable<KeyValuePair<PackageSource, HashSet<PackageIdentity>>> sourcesDescendingByPackageCount = null;
 
-            if (request.ReduceUnusedSourcesOption)
+            if (request.RemoveUnusedSourcesOption)
             {
                 Dictionary<PackageSource, HashSet<PackageIdentity>> sourcesToPackage = new();
 
-                logger.LogMinimal(Environment.NewLine + "    --reduce-unused-sources option requires internet connection to sources used for restore!");
+                logger.LogMinimal(Environment.NewLine + "    --remove-unused-sources option requires internet connection to sources used for restore!");
                 SourceCacheContext cache = new SourceCacheContext();
 
                 foreach (SourceRepository repository in _sourceRepositoryCache.Values)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Show help information
 
 Specify this option to generate full specified pattern instead without prefix. Currently only packages starting with `Microsoft, System, Runtime, Xunit` are prefixed by default.
 
-#### `--reduce-sources`
+#### `--reduce-unused-sources`
 
 Specify this option if the packagesourcemapper should attempt to reduce the number of sources used in nuget.config by consolidating them.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Show help information
 
 Specify this option to generate full specified pattern instead without prefix. Currently only packages starting with `Microsoft, System, Runtime, Xunit` are prefixed by default.
 
+#### `--reduce-sources`
+
+Specify this option if the packagesourcemapper should attempt to reduce the number of sources used in nuget.config by consolidating them.
+
 ### Examples
 
 Generate packageSourceMapping section:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Show help information
 
 Specify this option to generate full specified pattern instead without prefix. Currently only packages starting with `Microsoft, System, Runtime, Xunit` are prefixed by default.
 
-#### `--reduce-unused-sources`
+#### `--remove-unused-sources`
 
 Specify this option if the packagesourcemapper should attempt to reduce the number of sources used in nuget.config by consolidating them.
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/PackageSourceMapper/issues/7

I added new option `--reduce-sources` with this, tool will probe all sources for all packages for availability. Then it'll try to find if any sources could be removed using `greedy algorithm`, for each package would be tried from source with most package 1st by descending order. This `simple greedy algorithm` can be improved later, brute force solution which covers all possible scenario would be `O(n!*m)` time complexity, here n is number of sources and m is number of packages. Please note `O(n!*m)` is very steep increasing time complexity.
With simple greedy algorithm is `O(n*m)`, I believe which is more reasonable.

1. I added the following logging for this new option. It may seem verbose, but without it, the customer may think the tool is hanging and doing nothing. An alternative would be adding a progress bar, but that would require more work, which we can consider for a future update.
![image](https://user-images.githubusercontent.com/8766776/221254303-adcafa18-de14-4627-8cb2-7360edc74304.png)

2. I ran the tool on NuGet Insights repo before https://github.com/NuGet/Insights/commit/71d09e7534ce2e9e7b9699f443a18dc46b0028a8 change and it offers same suggestion which @joelverhagen made manually.
![image](https://user-images.githubusercontent.com/8766776/221273619-15d157a7-3e24-4681-972b-29284dee6d06.png)

4. Generate asset: 
[nugetPackageSourceMapping.txt](https://github.com/NuGet/PackageSourceMapper/files/10828038/nugetPackageSourceMapping.txt)
