### PR TITLE
Release stable version 1.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,8 +2,7 @@
 <Project>
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>0.1.3</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
     <!-- Libs -->


### PR DESCRIPTION
Fixes: https://github.com/NuGet/PackageSourceMapper/issues/40
This tool had been on nuget.org for quite a while, it's time to release stable version.
Also, now tool target `net6.0` instead of `netcore3.1`.